### PR TITLE
Minor updates for speed improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 500
+ignore = F401

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ var/
 .mypy_cache/
 .vscode
 .idea
+.pytest_cache/
+.pytest_cache
+__pycache__/
+__pycache__

--- a/pyunfurl/unfurl.py
+++ b/pyunfurl/unfurl.py
@@ -18,6 +18,7 @@ from uritools import urijoin, urisplit
 def get(url, timeout=15):
     return requests.get(url, timeout=timeout, headers={'User-Agent': 'Twitterbot/1.0'})
 
+
 def template(className, url, image, title, description, domain):
     return f"""<div class="unfurl {className}">
     <a rel="noopener nofollow" target="_blank" href="{url}">
@@ -176,8 +177,7 @@ def meta_tags(url, timeout=15, html=None):
         "description": d('meta[name="description"]').attr("content"),
         "image": d('meta[name="image"]').attr("content"),
         "favicon": favicon,
-        "url": d('meta[name="canonical"]').attr("content")
-        or d('meta[name="url"]').attr("content"),
+        "url": d('meta[name="canonical"]').attr("content") or d('meta[name="url"]').attr("content"),
         "keywords": d('meta[name="keywords"]').attr("content"),
     }
 
@@ -205,7 +205,7 @@ def oembed(url, timeout=15, html=None, refresh_oembed_provider_list=False):
         oembed_url = d('link[type="application/json+oembed"]').attr("href")
         if oembed_url:
             return get(oembed_url, timeout=timeout).json()
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         return None
 
     return None
@@ -238,6 +238,9 @@ def unfurl(url, timeout=15, html=None, refresh_oembed_provider_list=False):
     the list that is included with pyunfurl is used
     :return: dict
     """
+
+    if not html:
+        html = get(url, timeout=timeout).text
 
     data = custom_unfurl(url, timeout, html)
     if data:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -66,12 +66,12 @@ class UnitTests(unittest.TestCase):
             oembed["thumbnail_url"],
             "oembed:thumbnail_url",
         )
-        self.assertEqual(270, oembed["height"], "oembed:height")
+        self.assertEqual(113, oembed["height"], "oembed:height")
         self.assertEqual(
             "Adam Savage’s Tested", oembed["author_name"], "oembed:author_name"
         )
         self.assertEqual(
-            '<iframe width="480" height="270" src="https://www.youtube.com/embed/v-eK_cpTsOw?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+            '<iframe width="200" height="113" src="https://www.youtube.com/embed/v-eK_cpTsOw?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
             oembed["html"],
             "oembed:html",
         )


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

 - updated unfurl method to only call get(url) once instead of potentially 5 times, which should significantly reduce the response time of the tool, especially when needing to pull from meta tags.
 - add flake8 linting config
 - update tests so that they pass (youtube is returning some slightly different oembed responses it seems)
 - update gitignore to account for my testing and ignore some directories created while I was working on this.